### PR TITLE
handle duplicates in commit tree

### DIFF
--- a/pkg/service/vcs_event/utils.go
+++ b/pkg/service/vcs_event/utils.go
@@ -1,6 +1,8 @@
 package vcs_event
 
-import "strings"
+import (
+	"strings"
+)
 
 func RemoveDirectoryPrefix(s string) string {
 
@@ -12,4 +14,25 @@ func RemoveDirectoryPrefix(s string) string {
 	}
 
 	return s
+}
+
+func RemoveDuplicates(files []string, f string) []string {
+	ok, index := containsFile(f, files)
+
+	if ok {
+		files = append(files[:index], files[index+1:]...)
+	} else {
+		files = append(files, f)
+	}
+
+	return files
+}
+
+func containsFile(f string, files []string) (bool, int) {
+	for i, _ := range files {
+		if files[i] == f {
+			return true, i
+		}
+	}
+	return false, -1
 }

--- a/pkg/service/vcs_event/utils_test.go
+++ b/pkg/service/vcs_event/utils_test.go
@@ -1,7 +1,39 @@
 package vcs_event
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
+func TestExcludeRemovedFilesFromLangRequest(t *testing.T) {
+	tests := []struct {
+		in          []string
+		toBeRemoved string
+		expected    []string
+	}{
+		{
+			in: []string{
+				"main.clj",
+				"a.py",
+				"pom.xml",
+			},
+			toBeRemoved: "pom.xml",
+			expected: []string{
+				"main.clj",
+				"a.py",
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		result := RemoveDuplicates(test.in, test.toBeRemoved)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Fatalf("Expected %v, got %v", test.expected, result)
+		}
+	}
+
+}
 func TestRemoveDirectoryPrefix(t *testing.T) {
 	tests := []struct {
 		in  string

--- a/pkg/service/vcs_event/vcs_event.go
+++ b/pkg/service/vcs_event/vcs_event.go
@@ -61,13 +61,16 @@ func (s *vcsEventService) UpdateProject(project *model.Project) (*model.Project,
 			for _, commit := range branch.Commits {
 
 				for _, add := range commit.Added {
-					files = append(files, RemoveDirectoryPrefix(add))
+					files = RemoveDuplicates(files, RemoveDirectoryPrefix(add))
 				}
 
 				for _, mod := range commit.Modified {
-					files = append(files, RemoveDirectoryPrefix(mod))
+					files = RemoveDuplicates(files, RemoveDirectoryPrefix(mod))
 				}
-				//TODO handle removed files
+
+				for _, rem := range commit.Removed {
+					files = RemoveDuplicates(files, RemoveDirectoryPrefix(rem))
+				}
 			}
 
 			req.FileNames = files


### PR DESCRIPTION
Currently we calculate the languages every time we receive an event (this will change), we then traverse the commit tree for that particular branch and concat the added, mod and delete files from each commit. This could result in duplicate elements in the slice hence we remove duplicates (only for the language request)